### PR TITLE
Cleaned-up version of PR #21 - thanks to @gustawdaniel

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Run these commands to see some sample behavior:
     composer require symfony/symfony --update-with-all-dependencies
     composer audit
 
-By default this tool uploads your `composer.lock` file to the [security.sensiolabs.org](https://security.sensiolabs.org/) webservice which uses the checks from https://github.com/FriendsOfPHP/security-advisories. 
+By default this tool uploads your `composer.lock` file to the [security.symfony.com](https://security.symfony.com/) webservice which uses the checks from https://github.com/FriendsOfPHP/security-advisories. 
 
 You can check offline by downloading a local version of this [repo](https://github.com/FriendsOfPHP/security-advisories) and specify its path using:
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,9 @@
     },
     "require": {
         "composer-plugin-api": "^1.1",
-        "symfony/yaml": "^4.1"
+        "symfony/yaml": "^4.1",
+        "ext-json": "*",
+        "ext-curl": "*"
     },
     "require-dev": {
         "composer/composer": "^1.6",

--- a/src/Checker/HttpChecker.php
+++ b/src/Checker/HttpChecker.php
@@ -73,7 +73,7 @@ abstract class HttpChecker extends BaseChecker implements HttpCheckerInterface
 
     private function getCertFile()
     {
-        $certFile = __DIR__.'/../../res/security.sensiolabs.org.crt';
+        $certFile = __DIR__.'/../../res/security.symfony.com.crt';
 
         return $certFile;
     }

--- a/src/Checker/HttpCheckerInterface.php
+++ b/src/Checker/HttpCheckerInterface.php
@@ -5,7 +5,7 @@ namespace FancyGuy\Composer\SecurityCheck\Checker;
 interface HttpCheckerInterface extends CheckerInterface
 {
 
-    const DEFAULT_ENDPOINT = 'https://security.sensiolabs.org/check_lock';
+    const DEFAULT_ENDPOINT = 'https://security.symfony.com/check_lock';
     const DEFAULT_TIMEOUT = 20;
 
     /**


### PR DESCRIPTION
`security.sensiolabs.org` is replaced by `security.symfony.com`
Added requirement for the PHP extensions `curl` and `json`