### PR TITLE
Add in ability to save output report to a file. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Run these commands to see some sample behavior:
     composer audit
     composer audit --format=simple
     composer audit --format=json
+    composer audit --format=json --output-file=report.json
     composer validate
     composer require symfony/symfony --update-with-all-dependencies
     composer audit

--- a/src/Output/FileOutput.php
+++ b/src/Output/FileOutput.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace FancyGuy\Composer\SecurityCheck\Output;
+
+use FancyGuy\Composer\SecurityCheck\Exception\RuntimeException;
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+use Symfony\Component\Console\Output\StreamOutput;
+
+class FileOutput extends StreamOutput
+{
+    /**
+     * @param string                        $filePath  Full path to the file to append to
+     * @param int                           $verbosity The verbosity level (one of the VERBOSITY constants in OutputInterface)
+     * @param bool|null                     $decorated Whether to decorate messages (null for auto-guessing)
+     * @param OutputFormatterInterface|null $formatter Output formatter instance (null to use default OutputFormatter)
+     *
+     * @see Symfony\Component\Console\Output\StreamOutput::__construct
+     */
+    public function __construct(string $filePath, int $verbosity = self::VERBOSITY_NORMAL, bool $decorated = null, OutputFormatterInterface $formatter = null)
+    {
+        if (false === ($writeStream = fopen($filePath, 'a', false))) {
+            throw new RuntimeException(sprintf('Could not open write stream to: %s', $filePath));
+        }
+        parent::__construct($writeStream, $verbosity, $decorated, $formatter);
+    }
+
+    /**
+     * @throws RuntimeException Unable to close output file stream handle
+     */
+    public function __destruct()
+    {
+        if (!fclose($this->getStream())) {
+            throw new RuntimeException('Unable to close write stream handle');
+        }
+    }
+}


### PR DESCRIPTION
Particularly useful with json output.

I've been running this with the a local audit-db, however there doesn't seem to be a flag to silence the progress of reading this local DB.
I was sending the output of the command as a whole to a file using `>`, however that meant the above mentioned progress was also sent to the file (obviously)
e.g. 
```
   0/990 [>---------------------------]   0%
  99/990 [==>-------------------------]  10%
 198/990 [=====>----------------------]  20%
 297/990 [========>-------------------]  30%
 396/990 [===========>----------------]  40%
 495/990 [==============>-------------]  50%
 594/990 [================>-----------]  60%
 693/990 [===================>--------]  70%
 792/990 [======================>-----]  80%
 891/990 [=========================>--]  90%
 990/990 [============================] 100%
{
    "guzzlehttp\/guzzle": {
        "version": "5.3.4",
        "advisories": {
            "guzzlehttp\/guzzle\/CVE-2016-5385.yaml": {
                "title": "HTTP Proxy header vulnerability",
                "link": "https:\/\/github.com\/guzzle\/guzzle\/releases\/tag\/6.2.1",
                "cve": "CVE-2016-5385"
            }
        }
    }
}
```

The composer `--quiet` flag stops ALL output, including the json report, so I thought it might be an idea to allow the report to be output to a file. The code changes in this PR do this.