### PR TITLE
Updated to Composer 2.0 + HTTP/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Run these commands to see some sample behavior:
     mkdir insecure-project
     cd insecure-project
     composer init --name="insecure/project" --description="insecure project" -l MIT -n
-    composer require symfony/symfony:2.5.2
+    composer require 3f/pygmentize:1.0
     composer require fancyguy/composer-security-check-plugin
     composer audit
     composer audit --format=simple
     composer audit --format=json
     composer validate
-    composer require symfony/symfony --update-with-all-dependencies
+    composer require 3f/pygmentize --update-with-all-dependencies
     composer audit
 
 By default this tool uploads your `composer.lock` file to the [security.symfony.com](https://security.symfony.com/) webservice which uses the checks from https://github.com/FriendsOfPHP/security-advisories. 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Security Check Plugin for Composer
+# Security Check Plugin for Composer 2.x
 
 For global install:
 

--- a/composer.json
+++ b/composer.json
@@ -31,13 +31,10 @@
         "ext-curl": "*"
     },
     "require-dev": {
-        "composer/composer": "^1.6",
+        "composer/composer": "^2.0",
         "phpunit/phpunit": "^7.2"
     },
     "extra": {
-        "branch-alias": {
-            "dev-master": "1.2-dev"
-        },
         "class": "FancyGuy\\Composer\\SecurityCheck\\SecurityCheckPlugin"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,10 @@
         {
             "name": "Steve Buzonas",
             "email": "steve@fancyguy.com"
+        },
+        {
+            "name": "Jeroen Vermeulen",
+            "email": "jeroen@magehost.pro"
         }
     ],
     "support": {
@@ -21,7 +25,7 @@
         "psr-4": { "FancyGuy\\Composer\\SecurityCheck\\Test\\": "tests/" }
     },
     "require": {
-        "composer-plugin-api": "^1.1",
+        "composer-plugin-api": "^2.0",
         "symfony/yaml": "^4.1",
         "ext-json": "*",
         "ext-curl": "*"

--- a/src/Checker/HttpChecker.php
+++ b/src/Checker/HttpChecker.php
@@ -34,7 +34,7 @@ abstract class HttpChecker extends BaseChecker implements HttpCheckerInterface
 
         list($headers, $body) = $this->doHttpCheck($lock, $certFile);
 
-        if (!(preg_match('/X-Alerts: (\d+)/', $headers, $matches) || 2 == count($matches))) {
+        if (!(preg_match('/X-Alerts: (\d+)/i', $headers, $matches) || 2 == count($matches))) {
             throw new RuntimeException('The web service did not return alerts count.');
         }
 
@@ -59,7 +59,7 @@ abstract class HttpChecker extends BaseChecker implements HttpCheckerInterface
 
         unlink($tmplock);
 
-        if (!(preg_match('/X-Alerts: (\d+)/', $headers, $matches) || 2 == count($matches))) {
+        if (!(preg_match('/X-Alerts: (\d+)/i', $headers, $matches) || 2 == count($matches))) {
             throw new RuntimeException('The web service did not return alerts count.');
         }
 

--- a/src/SecurityCheckPlugin.php
+++ b/src/SecurityCheckPlugin.php
@@ -160,6 +160,9 @@ class SecurityCheckPlugin implements PluginInterface, Capable, EventSubscriberIn
         $im->addInstaller(new NoopInstaller);
 
         // TODO: Fake passes like in Installer::extractDevPackages() break things
+        //       Ideally we should have the local repository being used in the event
+        //       For now, blindly ignore exceptions. The noop installer throws only
+        //       when a package is not installed. We'll assume it is in another context
         try {
             $im->execute($localRepo, $operations);
         } catch (\Exception $e) {}


### PR DESCRIPTION
Switched to Composer 2, issue: fancyguy/composer-security-check-plugin#26
Added HTTP/2 support for the HttpChecker.
https://github.com/composer/composer/blob/master/UPGRADE-2.0.md#for-integrators-and-plugin-authors